### PR TITLE
Fix initialization bug and improve plugin utility

### DIFF
--- a/astrbot/core/initial_loader.py
+++ b/astrbot/core/initial_loader.py
@@ -26,13 +26,14 @@ class InitialLoader:
     async def start(self):
         core_lifecycle = AstrBotCoreLifecycle(self.log_broker, self.db)
 
-        core_task = []
         try:
             await core_lifecycle.initialize()
-            core_task = core_lifecycle.start()
         except Exception as e:
             logger.critical(traceback.format_exc())
             logger.critical(f"😭 初始化 AstrBot 失败：{e} !!!")
+            return
+
+        core_task = core_lifecycle.start()
 
         self.dashboard_server = AstrBotDashboard(
             core_lifecycle, self.db, core_lifecycle.dashboard_shutdown_event


### PR DESCRIPTION
## Summary
- fix AstrBot initialization failing to return when core init errors
- handle repositories with main branch when downloading plugin code
- broaden plugin metadata regex to match `@register` as well as `@register_star`

## Testing
- `ruff check .`
- *(tests not run: pytest unavailable in container)*