### PR TITLE
Add Google Agent SDK provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ AstrBot 是一个松耦合、异步、支持多消息平台部署、具有易用
 ## ✨ 近期更新
 
 1. AstrBot 现已支持接入 [MCP](https://modelcontextprotocol.io/) 服务器！
+2. 现已集成 [Google Agent SDK](https://google.github.io/adk-docs/)
+
 
 ## ✨ 主要功能
 
@@ -131,6 +133,7 @@ uvx astrbot init
 | OpenAI API | ✔    | 文本生成 | 也支持 DeepSeek、Google Gemini、GLM、Kimi、xAI 等兼容 OpenAI API 的服务 |
 | Claude API | ✔    | 文本生成 |  |
 | Google Gemini API | ✔    | 文本生成 |  |
+| Google Agent SDK | ✔    | Agent SDK | [https://google.github.io/adk-docs/](https://google.github.io/adk-docs/) |
 | Dify | ✔    | LLMOps |  |
 | 阿里云百炼应用 | ✔    | LLMOps |  |
 | Ollama | ✔    | 模型加载器 | 本地部署 DeepSeek、Llama 等开源语言模型 |

--- a/README_en.md
+++ b/README_en.md
@@ -82,6 +82,7 @@ See docs: [Source Code Deployment](https://astrbot.app/deploy/astrbot/cli.html)
 | OpenAI API                | ✔       | Text Generation        | Supports all OpenAI API-compatible services including DeepSeek, Google Gemini, GLM, Moonshot, Alibaba Cloud Bailian, Silicon Flow, xAI, etc. |
 | Claude API                | ✔       | Text Generation        |                                                                       |
 | Google Gemini API         | ✔       | Text Generation        |                                                                       |
+| Google Agent SDK          | ✔       | Agent SDK              | [Documentation](https://google.github.io/adk-docs/) |
 | Dify                      | ✔       | LLMOps                 |                                                                       |
 | DashScope (Alibaba Cloud) | ✔       | LLMOps                 |                                                                       |
 | Ollama                    | ✔       | Model Loader           | Local deployment for open-source LLMs (DeepSeek, Llama, etc.)         |

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -630,6 +630,17 @@ CONFIG_METADATA_2 = {
                             "budget": 0,
                         },
                     },
+                    "Google Agent SDK": {
+                        "id": "google_agent_default",
+                        "type": "google_agent_sdk",
+                        "provider_type": "chat_completion",
+                        "enable": False,
+                        "key": [],
+                        "timeout": 120,
+                        "model_config": {
+                            "model": "gemini-1.5-pro",
+                        },
+                    },
                     "DeepSeek": {
                         "id": "deepseek_default",
                         "type": "openai_chat_completion",

--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -170,6 +170,10 @@ class ProviderManager:
                     from .sources.gemini_source import (
                         ProviderGoogleGenAI as ProviderGoogleGenAI,
                     )
+                case "google_agent_sdk":
+                    from .sources.google_agent_sdk_source import (
+                        ProviderGoogleAgentSDK as ProviderGoogleAgentSDK,
+                    )
                 case "sensevoice_stt_selfhost":
                     from .sources.sensevoice_selfhosted_source import (
                         ProviderSenseVoiceSTTSelfHost as ProviderSenseVoiceSTTSelfHost,

--- a/astrbot/core/provider/sources/google_agent_sdk_source.py
+++ b/astrbot/core/provider/sources/google_agent_sdk_source.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncGenerator, List
+
+from astrbot.api.provider import Personality, Provider
+from astrbot.core.db import BaseDatabase
+from astrbot.core.message.message_event_result import MessageChain
+from astrbot.core.provider.entities import LLMResponse, ToolCallsResult
+from astrbot.core.provider.func_tool_manager import FuncCall
+from astrbot.core import logger
+from ..register import register_provider_adapter
+
+try:
+    from google.agents import Agent
+except Exception:  # pragma: no cover - optional dependency
+    Agent = None  # type: ignore
+
+
+@register_provider_adapter(
+    "google_agent_sdk", "Google Agent SDK 提供商适配器"
+)
+class ProviderGoogleAgentSDK(Provider):
+    """Provider adapter using Google Agent SDK.
+
+    This is a lightweight integration that forwards prompts to a Google Agent.
+    If the optional dependency is missing, initialization fails.
+    """
+
+    def __init__(
+        self,
+        provider_config: dict,
+        provider_settings: dict,
+        db_helper: BaseDatabase,
+        persistant_history: bool = True,
+        default_persona: Personality | None = None,
+    ) -> None:
+        super().__init__(
+            provider_config,
+            provider_settings,
+            persistant_history,
+            db_helper,
+            default_persona,
+        )
+
+        if Agent is None:
+            raise ImportError(
+                "google-agents SDK is required for google_agent_sdk provider"
+            )
+
+        self.api_key: str | None = None
+        keys = provider_config.get("key", [])
+        if keys:
+            self.api_key = keys[0]
+        self.set_model(provider_config.get("model_config", {}).get("model", ""))
+        # Actual Agent initialization; parameters may vary based on SDK version.
+        # TODO: pass additional configuration such as tools when needed.
+        self.agent = Agent(api_key=self.api_key, model=self.get_model())
+
+    def get_current_key(self) -> str:
+        return self.api_key or ""
+
+    def set_key(self, key: str) -> None:
+        self.api_key = key
+        # The Agent instance might need reconfiguration with new key.
+        try:
+            self.agent.api_key = key  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover - best effort
+            pass
+
+    def get_models(self) -> List[str]:  # pragma: no cover - simple return
+        return [self.get_model()]
+
+    async def text_chat(
+        self,
+        prompt: str,
+        session_id: str | None = None,
+        image_urls: List[str] | None = None,
+        func_tool: FuncCall | None = None,
+        contexts: List[dict] | None = None,
+        system_prompt: str | None = None,
+        tool_calls_result: ToolCallsResult | None = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Return chat completion via Google Agent SDK."""
+        if image_urls:
+            logger.warning("google_agent_sdk provider does not support images yet")
+        history = contexts or []
+        if system_prompt:
+            history = [{"role": "system", "content": system_prompt}, *history]
+        # TODO: handle func_tool and tool_calls_result via ADK Tool API
+        try:
+            response = await self.agent.chat(prompt, history=history)  # type: ignore[attr-defined]
+        except Exception as e:  # pragma: no cover - runtime errors
+            raise Exception(f"Google Agent SDK error: {e}") from e
+        llm_response = LLMResponse("assistant")
+        llm_response.result_chain = MessageChain().message(str(response))
+        llm_response.raw_completion = response
+        return llm_response
+
+    async def text_chat_stream(
+        self,
+        prompt: str,
+        session_id: str | None = None,
+        image_urls: List[str] | None = None,
+        func_tool: FuncCall | None = None,
+        contexts: List[dict] | None = None,
+        system_prompt: str | None = None,
+        tool_calls_result: ToolCallsResult | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[LLMResponse, None]:
+        """Stream chat completions via Google Agent SDK."""
+        llm_response = await self.text_chat(
+            prompt,
+            session_id=session_id,
+            image_urls=image_urls,
+            func_tool=func_tool,
+            contexts=contexts,
+            system_prompt=system_prompt,
+            tool_calls_result=tool_calls_result,
+            **kwargs,
+        )
+        yield llm_response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "faiss-cpu>=1.11.0",
     "filelock>=3.18.0",
     "google-genai>=1.14.0",
+    "google-agents>=0.1.0",
     "googlesearch-python>=1.3.0",
     "lark-oapi>=1.4.15",
     "lxml-html-clean>=0.4.2",


### PR DESCRIPTION
## Summary
- add new `google_agent_sdk` provider using Google Agent SDK
- integrate provider into manager and default config
- document support in READMEs
- list dependency in pyproject

## Testing
- `ruff check astrbot/core/provider/sources/google_agent_sdk_source.py`
- `ruff check astrbot/core/provider/manager.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'quart')*