### PR TITLE
Add Google Chat platform adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ uvx astrbot init
 | 微信客服    | ✔    | 私聊 | 文字、图片 |
 | 飞书   | ✔    | 私聊、群聊 | 文字、图片 |
 | 钉钉   | ✔    | 私聊、群聊 | 文字、图片 |
+| Google Chat | ✔    | 私聊、群聊 | 文字 |
 | 微信对话开放平台 | 🚧    | 计划内 | - |
 | Discord   | 🚧    | 计划内 | - |
 | WhatsApp   | 🚧    | 计划内 | - |
@@ -150,6 +151,13 @@ uvx astrbot init
 | Edge TTS | ✔    | 文本转语音 | Edge 浏览器的免费 TTS |
 | 阿里云百炼 TTS | ✔    | 文本转语音 |  |
 | Azure TTS | ✔    | 文本转语音 | Microsoft Azure TTS |
+
+### Google Chat 配置示例
+1. 在 Google Chat 中创建 Incoming Webhook
+2. 将生成的 Webhook URL 填入 `google_chat_webhook_url`
+3. 如需接收消息，设置 `google_chat_verification_token`、`google_chat_callback_server_host` 和 `google_chat_port`
+4. 配置 `google_chat_bot_name` 为机器人显示名称
+5. 重启 AstrBot 使配置生效
 
 
 ## ❤️ 贡献

--- a/README_en.md
+++ b/README_en.md
@@ -70,6 +70,7 @@ See docs: [Source Code Deployment](https://astrbot.app/deploy/astrbot/cli.html)
 | [Telegram](https://github.com/Soulter/astrbot_plugin_telegram) | ✔      | Private/Group chats | Text, Images        |
 | [WeChat Work](https://github.com/Soulter/astrbot_plugin_wecom) | ✔      | Private chats       | Text, Images, Voice |
 | Feishu                                                         | ✔      | Group chats         | Text, Images        |
+| Google Chat                                                    | ✔      | Private/Group chats | Text |
 | WeChat Open Platform                                           | 🚧      | Planned             | -                   |
 | Discord                                                        | 🚧      | Planned             | -                   |
 | WhatsApp                                                       | 🚧      | Planned             | -                   |
@@ -93,6 +94,13 @@ See docs: [Source Code Deployment](https://astrbot.app/deploy/astrbot/cli.html)
 | SenseVoice                | ✔       | Speech-to-Text         | Local deployment                                                     |
 | OpenAI TTS API            | ✔       | Text-to-Speech         |                                                                       |
 | Fishaudio                 | ✔       | Text-to-Speech         | Project involving GPT-Sovits author                                  |
+### Google Chat Configuration
+1. Create an incoming webhook in Google Chat
+2. Put the generated URL in `google_chat_webhook_url`
+3. To receive messages, set `google_chat_verification_token`, `google_chat_callback_server_host` and `google_chat_port`
+4. Set `google_chat_bot_name` as the bot display name
+5. Restart AstrBot to apply changes
+
 
 # 🦌 Roadmap
 

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -221,6 +221,16 @@ CONFIG_METADATA_2 = {
                         "telegram_command_auto_refresh": True,
                         "telegram_command_register_interval": 300,
                     },
+                    "google_chat": {
+                        "id": "google_chat",
+                        "type": "google_chat",
+                        "enable": False,
+                        "webhook_url": "",
+                        "verification_token": "",
+                        "callback_server_host": "0.0.0.0",
+                        "port": 6200,
+                        "bot_name": "astrbot",
+                    },
                 },
                 "items": {
                     "active_send_mode": {
@@ -319,6 +329,31 @@ CONFIG_METADATA_2 = {
                         "type": "string",
                         "hint": "请务必填对，否则 @ 机器人将无法唤醒，只能通过前缀唤醒。",
                         "obvious_hint": True,
+                    },
+                    "google_chat_webhook_url": {
+                        "description": "Google Chat Webhook URL",
+                        "type": "string",
+                        "hint": "发送消息到 Google Chat 的 Webhook 地址",
+                    },
+                    "google_chat_verification_token": {
+                        "description": "Google Chat 验证 Token",
+                        "type": "string",
+                        "hint": "可选，用于验证来自 Google Chat 的回调请求",
+                    },
+                    "google_chat_callback_server_host": {
+                        "description": "Google Chat 回调服务器 Host",
+                        "type": "string",
+                        "hint": "监听回调的服务器地址",
+                    },
+                    "google_chat_port": {
+                        "description": "Google Chat 回调服务器端口",
+                        "type": "int",
+                        "hint": "监听回调的服务器端口",
+                    },
+                    "google_chat_bot_name": {
+                        "description": "Google Chat 机器人名称",
+                        "type": "string",
+                        "hint": "机器人在 Google Chat 中显示的名称",
                     },
                 },
             },

--- a/astrbot/core/platform/manager.py
+++ b/astrbot/core/platform/manager.py
@@ -74,6 +74,10 @@ class PlatformManager:
                     )
                 case "telegram":
                     from .sources.telegram.tg_adapter import TelegramPlatformAdapter  # noqa: F401
+                case "google_chat":
+                    from .sources.google_chat.google_chat_adapter import (
+                        GoogleChatPlatformAdapter,  # noqa: F401
+                    )
                 case "wecom":
                     from .sources.wecom.wecom_adapter import WecomPlatformAdapter  # noqa: F401
                 case "weixin_official_account":

--- a/astrbot/core/platform/sources/google_chat/google_chat_adapter.py
+++ b/astrbot/core/platform/sources/google_chat/google_chat_adapter.py
@@ -1,0 +1,125 @@
+import asyncio
+import uuid
+import quart
+import astrbot.api.message_components as Comp
+from astrbot.api.platform import (
+    Platform,
+    AstrBotMessage,
+    MessageMember,
+    MessageType,
+    PlatformMetadata,
+)
+from astrbot.api.event import MessageChain
+from astrbot.core.platform.astr_message_event import MessageSesion
+from .google_chat_event import GoogleChatMessageEvent
+from ...register import register_platform_adapter
+from astrbot import logger
+
+
+class GoogleChatServer:
+    def __init__(self, adapter: "GoogleChatPlatformAdapter", config: dict):
+        self.adapter = adapter
+        self.port = int(config.get("port", 6200))
+        self.host = config.get("callback_server_host", "0.0.0.0")
+        self.verification_token = config.get("verification_token", "")
+        self.server = quart.Quart(__name__)
+        self.server.add_url_rule(
+            "/astrbot-googlechat/callback", view_func=self.callback, methods=["POST"]
+        )
+        self.shutdown_event = asyncio.Event()
+
+    async def callback(self):
+        data = await quart.request.get_json()
+        token = quart.request.headers.get("Authorization")
+        if self.verification_token and token != f"Bearer {self.verification_token}":
+            logger.warning("Google Chat verification failed")
+            return {"success": False}, 403
+        await self.adapter.on_event(data)
+        return {"success": True}
+
+    async def start_polling(self):
+        logger.info(
+            f"Google Chat adapter listening on {self.host}:{self.port}"
+        )
+        await self.server.run_task(
+            host=self.host, port=self.port, shutdown_trigger=self.shutdown_trigger
+        )
+
+    async def shutdown_trigger(self):
+        await self.shutdown_event.wait()
+
+    async def shutdown(self):
+        self.shutdown_event.set()
+
+
+@register_platform_adapter("google_chat", "Google Chat 适配器")
+class GoogleChatPlatformAdapter(Platform):
+    def __init__(
+        self, platform_config: dict, platform_settings: dict, event_queue: asyncio.Queue
+    ) -> None:
+        super().__init__(event_queue)
+        self.config = platform_config
+        self.settings = platform_settings
+        self.bot_name = platform_config.get("bot_name", "astrbot")
+        self.unique_session = platform_settings["unique_session"]
+        self.server = GoogleChatServer(self, platform_config)
+
+    async def send_by_session(self, session: MessageSesion, message_chain: MessageChain):
+        await GoogleChatMessageEvent._send_chain(session.session_id, message_chain)
+        await super().send_by_session(session, message_chain)
+
+    def meta(self) -> PlatformMetadata:
+        return PlatformMetadata(
+            name="google_chat", description="Google Chat 适配器", id=self.config.get("id")
+        )
+
+    async def on_event(self, payload: dict):
+        abm = await self.convert_message(payload)
+        if abm:
+            await self.handle_msg(abm)
+
+    async def convert_message(self, payload: dict) -> AstrBotMessage | None:
+        if payload.get("type") != "MESSAGE":
+            return None
+        message = payload.get("message", {})
+        sender = message.get("sender", {})
+        text = message.get("text", "")
+
+        abm = AstrBotMessage()
+        abm.message_id = message.get("name", str(uuid.uuid4()))
+        abm.sender = MessageMember(
+            user_id=sender.get("name", ""), nickname=sender.get("displayName", "")
+        )
+        abm.self_id = self.bot_name
+        abm.message_str = text
+        abm.message = [Comp.Plain(text)] if text else []
+
+        space = payload.get("space", {})
+        if space.get("type") == "ROOM":
+            abm.type = MessageType.GROUP_MESSAGE
+            abm.group_id = space.get("name")
+        else:
+            abm.type = MessageType.FRIEND_MESSAGE
+        abm.session_id = payload.get("responseUrl", self.config.get("webhook_url", ""))
+        abm.raw_message = payload
+        abm.timestamp = int(payload.get("eventTime", 0)) if isinstance(payload.get("eventTime"), int) else 0
+        return abm
+
+    async def handle_msg(self, abm: AstrBotMessage):
+        event = GoogleChatMessageEvent(
+            message_str=abm.message_str,
+            message_obj=abm,
+            platform_meta=self.meta(),
+            session_id=abm.session_id,
+        )
+        self.commit_event(event)
+
+    async def run(self):
+        await self.server.start_polling()
+
+    async def terminate(self):
+        await self.server.shutdown()
+        logger.info("Google Chat adapter shutdown")
+
+    def get_client(self):
+        return self.server

--- a/astrbot/core/platform/sources/google_chat/google_chat_event.py
+++ b/astrbot/core/platform/sources/google_chat/google_chat_event.py
@@ -1,0 +1,26 @@
+import aiohttp
+from astrbot.api.event import AstrMessageEvent, MessageChain
+from astrbot.api.message_components import Plain
+from astrbot import logger
+
+
+class GoogleChatMessageEvent(AstrMessageEvent):
+    @staticmethod
+    async def _send_chain(webhook_url: str, message: MessageChain):
+        text = ""
+        for comp in message.chain:
+            if isinstance(comp, Plain):
+                text += comp.text
+        payload = {"text": text or ""}
+        async with aiohttp.ClientSession() as session:
+            async with session.post(webhook_url, json=payload) as resp:
+                if resp.status != 200:
+                    try:
+                        error_text = await resp.text()
+                    except Exception:
+                        error_text = resp.status
+                    logger.error(f"Failed to send Google Chat message: {error_text}")
+
+    async def send(self, message: MessageChain):
+        await self._send_chain(self.session_id, message)
+        await super().send(message)


### PR DESCRIPTION
## Summary
- add basic Google Chat adapter and event class
- register adapter in platform manager
- configure default google_chat options
- document Google Chat support in readmes
- add short Google Chat configuration tutorial

## Testing
- `python -m py_compile astrbot/core/platform/sources/google_chat/google_chat_adapter.py astrbot/core/platform/sources/google_chat/google_chat_event.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'quart')*
